### PR TITLE
Migrate state locking from deprecated DynamoDB to S3 native locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,42 @@
 
 This repo was created as part of the blog - "Best practices for managing Terraform State files in AWS CI/CD Pipeline" 
 
+## Prerequisites
+
+- Terraform v1.11.0 or later (required for S3 native state locking with `use_lockfile`)
+
 ## Best Practices for handling state files
 
-The recommended practice for managing state files is to use terraform’s built-in support for remote backends.
+The recommended practice for managing state files is to use terraform's built-in support for remote backends.
 
 Remote backend on Amazon Simple Storage Service (Amazon S3): 
 You can configure terraform to store state files in an Amazon S3 bucket which provides a durable and scalable storage solution for your state files. Storing on Amazon S3 also enables collaboration that allows you to share state file with others.
 
-Remote backend on Amazon S3 with Amazon DynamoDB: 
-In addition to using an Amazon S3 bucket for managing the files, you can use an Amazon DynamoDB table to lock the state file so that only one person can modify a particular state file at any given time. This will help to avoid conflicts and enable safe concurrent access to the state file.
+State locking with S3 native locking:
+By setting `use_lockfile = true` in the S3 backend configuration, Terraform creates a `.tflock` lock file in the same S3 bucket to prevent concurrent modifications to the state file. This eliminates the need for a separate DynamoDB table and simplifies your infrastructure.
 
-When deploying terraform on AWS, the preferred choice of managing state is using Amazon S3 with Amazon DynamoDB.
+> **Note:** `use_lockfile` requires Terraform v1.11.0 or later.
+
+When deploying terraform on AWS, the preferred choice of managing state is using Amazon S3 with S3 native locking (`use_lockfile = true`).
 
 ## AWS configurations for managing state files
 
+> **Important:** Before deploying, update the S3 bucket name in both `variable.tf` (`s3_bucket_name`) and `backend.tf` (`bucket`) to a globally unique name for your environment. These two values must refer to the same bucket.
+
 1. Create an Amazon S3 bucket using terraform. Implement security measures for Amazon S3 bucket by creating an AWS Identity and Access Management (AWS IAM) policy or Amazon S3 Bucket Policy for restricting access, configuring object versioning for data protection and recovery, and enabling AES256 encryption with SSE-KMS for encryption control.
 
-2. Next create an Amazon DynamoDB table using terraform with Primary key set to LockID and any additional configuration options such as read/write capacity units. Once the table is created, you will configure the terraform backend to use it for state locking by specifying the table name in the terraform block of your configuration.
+2. Configure the S3 backend with `use_lockfile = true` to enable state locking. Terraform will automatically manage a `.tflock` file in the S3 bucket to prevent concurrent state modifications. Ensure the IAM role used by Terraform has the minimum permissions: `s3:ListBucket` on the bucket, `s3:GetObject` and `s3:PutObject` on the state file, and additionally `s3:DeleteObject` on the lock file (`.tflock`).
 
 3. For a single AWS account with multiple environments and projects, you can use a single Amazon S3 bucket. If you have multiple applications in multiple environments across multiple AWS accounts, you can create one Amazon S3 bucket for each account. In that Amazon S3 bucket, you can create appropriate folders for each environment, storing project state files with specific prefixes.
 
 This repo will explain how you can manage terraform state files efficiently in your Continuous Integration pipeline in AWS when used with AWS Developer Tools like AWS CodeCommit and AWS CodeBuild. 
 
+## Migrating from DynamoDB state locking
 
+If you are currently using DynamoDB-based state locking (`dynamodb_table`), note that this mechanism is deprecated as of Terraform v1.11.0 and will be removed in a future minor version. The [HashiCorp S3 Backend documentation](https://developer.hashicorp.com/terraform/language/backend/s3) recommends the following migration path:
+
+1. **Dual locking:** Add `use_lockfile = true` while keeping the existing `dynamodb_table` argument. Terraform will acquire locks from both S3 and DynamoDB before proceeding with any operation.
+2. **Verify:** Run `plan` and `apply` several times to confirm S3 native locking is working correctly.
+3. **Remove DynamoDB configuration:** Once verified, remove the `dynamodb_table` argument to complete the migration and eliminate the deprecation warning. The DynamoDB table and its associated IAM permissions can then be removed.
+
+> **Note:** If your team has mixed Terraform versions, remain in the dual locking state until everyone has upgraded to v1.11.0 or later. S3 native locking relies on conditional writes (`If-None-Match` header), which may not be supported by all S3-compatible storage providers.

--- a/backend.tf
+++ b/backend.tf
@@ -3,7 +3,7 @@ terraform {
     bucket         = "tfbackend-bucket"
     key            = "terraform.tfstate"
     region         = "eu-central-1"
-    dynamodb_table = "tfstate-lock"
+    use_lockfile   = true
     encrypt        = true
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -6,34 +6,31 @@ data "aws_iam_policy_document" "codebuild_policy_document" {
     resources = ["arn:aws:logs:*:*:*"]
     effect    = "Allow"
   }
+  # Get a list of S3 buckets
   statement {
-    actions = [
-      "s3:List*",
-      "s3:Get*",
-      "s3:Put*",
-      "s3:DeleteObject",
-      "s3:DeleteObjectVersion"
-    ]
+    effect  = "Allow"
+    actions = ["s3:ListBucket"]
     resources = [
-      "${aws_s3_bucket.s3_bucket_backend.arn}/*",
-      "${aws_s3_bucket.s3_bucket_backend.arn}"
+      aws_s3_bucket.s3_bucket_backend.arn
     ]
-    effect = "Allow"
   }
+
+  # Write/read state file (No DeleteObject permission)
   statement {
-    effect = "Allow"
-    actions = [
-      "dynamodb:BatchGetItem",
-      "dynamodb:Query",
-      "dynamodb:PutItem",
-      "dynamodb:UpdateItem",
-      "dynamodb:DeleteItem",
-      "dynamodb:BatchWriteItem",
-      "dynamodb:Describe*",
-      "dynamodb:Get*",
-      "dynamodb:List*"
+    effect  = "Allow"
+    actions = ["s3:GetObject", "s3:PutObject"]
+    resources = [
+      "${aws_s3_bucket.s3_bucket_backend.arn}/terraform.tfstate"
     ]
-    resources = ["${aws_dynamodb_table.dynamodb_tfstate_lock.arn}"]
+  }
+
+  # write/read/delete lock file
+  statement {
+    effect  = "Allow"
+    actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = [
+      "${aws_s3_bucket.s3_bucket_backend.arn}/terraform.tfstate.tflock"
+    ]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -140,27 +140,6 @@ resource "aws_codebuild_project" "codebuild_project_apply" {
 #   runtime          = "python3.9"
 # }
 
-#### DynamoDB
-
-resource "aws_dynamodb_table" "dynamodb_tfstate_lock" {
-  #checkov:skip=CKV2_AWS_16: Auto Scaling not required for TF state bucket
-  #checkov:skip=CKV_AWS_28: Dynamodb point in time recovery not required for TF state bucket
-  #checkov:skip=CKV_AWS_119: KMS Customer Managed CMK not required for TF state bucket
-  name           = "tfstate-lock"
-  hash_key       = "LockID"
-  read_capacity  = 20
-  write_capacity = 20
-
-  attribute {
-    name = "LockID"
-    type = "S"
-  }
-
-  server_side_encryption {
-    enabled = true
-  }
-
-}
 
 #### Cloudwatch log group
 


### PR DESCRIPTION
- Replace dynamodb_table with use_lockfile = true in backend.tf
- Remove aws_dynamodb_table resource from main.tf
- Remove DynamoDB IAM permissions and apply least-privilege S3 policy per HashiCorp official documentation in iam.tf
- Update README.md to reflect S3 native locking best practices and add migration guide for existing DynamoDB users

Terraform v1.11.0 deprecated DynamoDB-based state locking in favor of S3 native locking using .tflock files with conditional writes.

Ref: https://developer.hashicorp.com/terraform/language/backend/s3

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
